### PR TITLE
fix bug at @get_connection_by_slot: fix node[2] nil error (this the p…

### DIFF
--- a/resty/redis_cluster.lua
+++ b/resty/redis_cluster.lua
@@ -1,6 +1,20 @@
 local redis = require "resty.redis"
 local bit = require "bit"
 
+--字符串分割函数
+--传入字符串和分隔符，返回分割后的table
+function Split(str, delimiter)
+    if str==nil or str=='' or delimiter==nil then
+        return nil
+    end
+
+    local result = {}
+    for match in (str..delimiter):gmatch("(.-)"..delimiter) do
+        table.insert(result, match)
+    end
+    return result
+end
+
 local setmetatable = setmetatable
 local pairs = pairs
 local sub = string.sub
@@ -319,6 +333,12 @@ function _M.get_connection_by_slot(self, slot)
 
     if node == nil then
         return self:get_random_connection()
+    end
+
+    if node[2] == nil then
+        local addr = Split(node[3], ':')
+        local ports = Split(addr[2], '@')
+        node[2] = ports[1]
     end
 
     return get_redis_link(node[1], node[2], cluster.timeout)


### PR DESCRIPTION
在我的环境中运行此代码会碰到这个问题：
get_connection_by_slot方法获取当前槽对应连接时，表示端口的node表元素2（node[2]）为nil导致错误

经过检查代码，发现node[3]中可以正常获取到host:port@adminPort，所以做了个临时解决方案
- 如果node2为nil，则从node3中解析端口值并赋值给node2

---
附上调试代码与log：

``` lua
330 function _M.get_connection_by_slot(self, slot)
331     ngx.log(ngx.DEBUG, "self.cluster_id: ", self.cluster_id)
332     local cluster = clusters[self.cluster_id]
333     ngx.log(ngx.DEBUG, "slot: ", slot)
334     local node = cluster.slots[slot]
335
336     if node == nil then
337         return self:get_random_connection()
338     end
339
340     ngx.log(ngx.DEBUG, "#node: ", #node)
341     for k,v in pairs(node) do
342         ngx.log(ngx.DEBUG, "k: ", k, ", v: ", v)
343     end
344     if node[2] == nil then
345         ngx.log(ngx.DEBUG, "node[2] is nil, try to get form node[3]: ", node[3])
346         local addr = Split(node[3], ':')
347         ngx.log(ngx.DEBUG, "addr[1]: ", addr[1], " , addr[2]: ", addr[2])
348         local ports = Split(addr[2], '@')
349         ngx.log(ngx.DEBUG, "ports[1]: ", ports[1], " , ports[2]: ", ports[2])
350         node[2] = ports[1]
351     end
352
353     ngx.log(ngx.DEBUG, "node[2]: ", node[2])
354     return get_redis_link(node[1], node[2], cluster.timeout)
355 end
```

``` log
[debug] redis_cluster.lua:331: get_connection_by_slot(): self.cluster_id: redis_cluster
[debug] redis_cluster.lua:333: get_connection_by_slot(): slot: 10440
[debug] redis_cluster.lua:340: get_connection_by_slot(): #node: 3
[debug] redis_cluster.lua:342: get_connection_by_slot(): k: 1, v: 10.0.20.202
[debug] redis_cluster.lua:342: get_connection_by_slot(): k: 3, v: 10.0.20.202:7001@17001
[debug] redis_cluster.lua:345: get_connection_by_slot(): node[2] is nil, try to get form node[3]: 10.0.20.202:7001@17001
[debug] redis_cluster.lua:347: get_connection_by_slot(): addr[1]: 10.0.20.202 , addr[2]: 7001@17001
[debug] redis_cluster.lua:349: get_connection_by_slot(): ports[1]: 7001 , ports[2]: 17001
[debug] redis_cluster.lua:353: get_connection_by_slot(): node[2]: 7001
```